### PR TITLE
hotfix: Fix find non-exist users

### DIFF
--- a/src/main/java/com/example/fastcampusmysql/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/fastcampusmysql/domain/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.example.fastcampusmysql.domain.member.repository;
 
 import com.example.fastcampusmysql.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -42,8 +43,9 @@ public class MemberRepository {
         var param = new MapSqlParameterSource()
                 .addValue("id", id);
 
-        var member = namedParameterJdbcTemplate.queryForObject(sql, param, rowMapper);
-        return Optional.ofNullable(member);
+        var members = namedParameterJdbcTemplate.query(sql, param, rowMapper);
+        Member nullableMember = DataAccessUtils.singleResult(members);
+        return Optional.ofNullable(nullableMember);
     }
 
     public List<Member> findAllByIdIn(List<Long> ids) {


### PR DESCRIPTION
존재하지 않는 유저 조회 시 repository의 queryForObject 부분에서 예외 발생하는 점 수정
* 대신 null을 리턴
* ReadService에서 예외 발생하도록 수정